### PR TITLE
Update README with eslint-plugin-boundaries support details

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Plugins:
 - [eslint-plugin-boundaries](https://github.com/javierbrea/eslint-plugin-boundaries).
 
 > [!WARNING]  
-> `eslint-plugin-boundaries` does not support ESLint 9.
+> `eslint-plugin-boundaries` versions prior to version 5.0.0 do not support ESLint 9 
 
 If you want to compare the configurations of both plugins:
 


### PR DESCRIPTION
Clarified compatibility information for eslint-plugin-boundaries. There are no ambiguities of whether the plugin may be deprecated. Other suggestion is to remove the warning altogether.